### PR TITLE
Update Python 3.6 to 3.9

### DIFF
--- a/get_forecast_cf.yaml
+++ b/get_forecast_cf.yaml
@@ -72,7 +72,7 @@ Resources:
       Role: !GetAtt getForecastFunctionRole.Arn
       Timeout: 30
       Handler: get_forecast.lambda_handler
-      Runtime: python3.6
+      Runtime: python3.9
       Code:
         S3Bucket: jimzucker-github-getforecast
         S3Key: get_forecast.zip


### PR DESCRIPTION
Python 3.6 is deprecated for creation/updates of lambda functions. I have changed the runtime of the lambda function from 3.6 to 3.9